### PR TITLE
Fix lGetRange typo

### DIFF
--- a/web-app/app/service.php
+++ b/web-app/app/service.php
@@ -45,7 +45,7 @@ function add_message($sender, $receiver, $payload)
 function get_messages_list($uid)
 {
     $messages_count = Storage::lLen("messages_to_uid:$uid");
-    $message_ids = Storage::lGetRage("messages_to_uid:$uid", 0, $messages_count);
+    $message_ids = Storage::lGetRange("messages_to_uid:$uid", 0, $messages_count);
     return $message_ids;
 }
 
@@ -70,7 +70,7 @@ function clear_message($uid, $msg_id)
 function clear_uid($uid)
 {
     $messages_count = Storage::lLen("messages_to_uid:$uid");
-    $message_ids = Storage::lGetRage("messages_to_uid:$uid", 0, $messages_count);
+    $message_ids = Storage::lGetRange("messages_to_uid:$uid", 0, $messages_count);
     foreach ($message_ids as $message_id)
     {
         Storage::del("msg:$message_id");

--- a/web-app/microfw/storage.php
+++ b/web-app/microfw/storage.php
@@ -108,10 +108,18 @@ class Storage
         return self::$r->lLen($list_key);
     }
     
-    public static function lGetRage($list_key, $start, $end)
+    /**
+     * Retrieve a range of elements from a list.
+     *
+     * @param string $list_key List key name
+     * @param int $start Start index
+     * @param int $end End index
+     * @return array Decoded list elements
+     */
+    public static function lGetRange($list_key, $start, $end)
     {
         return self::decodeArray(self::$r->lGetRange($list_key, $start, $end));
-        
+
     }
     
     public static function lGet($list_key, $index)


### PR DESCRIPTION
## Summary
- rename `lGetRage` to `lGetRange`
- update service layer to use new name
- add PHPDoc for `lGetRange`

## Testing
- `composer validate --no-interaction -q` *(fails: composer not found)*
- `php -l web-app/microfw/storage.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453203b4e88324a06b06234d3b95d1