### PR TITLE
Fix composer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,14 @@ Run:
 
 ```bash
 cd web-app
-./composer.phat install
+./composer.phar install
 ```
 
 Or if you've installed composer into your PATH:
 
 ```bash
 cd web-app
-composer.phat install
+composer.phar install
 ```
 
 5. Generate public and private keys for usage with JWT:


### PR DESCRIPTION
## Summary
- correct composer binary name in README

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684535c4facc8324bd72b20fc1dc110d