### PR TITLE
Fix IntervalCaller stop function

### DIFF
--- a/web-app/public/js/shared.js
+++ b/web-app/public/js/shared.js
@@ -345,7 +345,7 @@ class IntervalCaller{
             if (this.interval)
             {
                 clearInterval(this.interval);
-                this.inteval = null;
+                this.interval = null;
             }
         };
     };


### PR DESCRIPTION
## Summary
- fix typo in `IntervalCaller.stop` that prevented clearing stored interval reference

## Testing
- `node - <<'NODE'
const fs=require('fs');
const code=fs.readFileSync('./web-app/public/js/shared.js','utf8');
const IntervalCaller = eval(code + '; IntervalCaller');
let c = new IntervalCaller(()=>{}, 10, 'test');
c.start();
setTimeout(()=>{c.stop(); console.log('stopped interval:', c.interval);}, 50);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68454d7cc81c8324b1cd72c8b3a387d7