### PR TITLE
Fix broadcast and ping in service worker

### DIFF
--- a/web-app/public/js/sw.js
+++ b/web-app/public/js/sw.js
@@ -13,10 +13,11 @@ var lib = {
     on_install: function(event){
         self.importScripts('shared.js');
         lib.broadcast = new BroadcastMessanger();
-        lib.boradcast.init();
+        lib.broadcast.init();
         lib.ping_to_pages = new IntervalCaller(function(){
-            lib.broadcast.send("sw.ping", {"ping_num": randint(1, Math.pow(10, 6))})
+            lib.broadcast.post("sw.ping", {"ping_num": randint(1, Math.pow(10, 6))})
         }, 1000, "ping_to_pages", true);
+        lib.ping_to_pages.start();
     },
     send_to_all_clients: function(type, data)
     {


### PR DESCRIPTION
## Summary
- fix broadcast init typo in `sw.js`
- use `broadcast.post` instead of `broadcast.send`
- start the ping interval

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68454d83442483248016f1ac209f8acd