### PR TITLE
Add optional “Resend to new” mode to re-send past messages to newly added receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Website: https://cryptboard.io/
 * All sent data encrypted on the client and could not be decrypted by the server
 * Clients adding each other to the "receivers list" by sending their public key and user ID using third-party channel
 * Possible to add public key and user ID by scanning QR-code
+* Optional "Resend to new" checkbox on Clipboard page re-sends your previously sent text/file/key-share messages to newly added receivers
 * Single button click to clear all client's data and keys and start a new session
 
 ## Disclaimers
@@ -39,6 +40,7 @@ Website: https://cryptboard.io/
     * You can copy the link on the "Share key" page and send it over some other messenger or email
     * Also, you can copy QR code (make a screenshot) and send it over other messenger or email
 * Device where your uid and the public key is added could automatically send its uid and public key back encrypted if the checkbox "Send my key back" is checked (by default it is)
+* On Clipboard page, if "Resend to new" is enabled, outgoing text, file and key-share messages from your local history are automatically re-sent when a new receiver key arrives via add-contact message
 * After uid and key is added you can send text or files back and forth between devices (or people)
 * Avatars should be used to check if uid and the public key wasn't changed while traveling through third-party messenger
 
@@ -323,4 +325,3 @@ FRONTEND_POLL_REFRESH_AUTH_MS=60000
 Here `31536000` is approximately 1 year in seconds. You can increase it further if needed.
 
 > Important: very large TTL values increase the risk of long-lived compromised sessions. Choose production values according to your threat model.
-

--- a/SPEC.md
+++ b/SPEC.md
@@ -23,6 +23,7 @@ The core design principle is: the server transports opaque payloads and authenti
 - image preview for loaded image files
 - receiver/contact list with avatars derived from UID + public key
 - deterministic avatars used as a simple visual integrity check for the `uid + public_key` pair during key exchange
+- optional "Resend to new" mode: when enabled, previously sent local text/file/key-share messages are re-sent to a newly added receiver after receiving their add-contact packet
 - multi-tab coordination
 - multilingual UI: English, Russian, Simplified Chinese
 - kill-session workflow that clears both server and browser state

--- a/web-app/public/css/style.css
+++ b/web-app/public/css/style.css
@@ -499,6 +499,11 @@ main .tab.active
     max-width: 500px;
 }
 
+.receivers-option
+{
+    margin: 8px 0 10px 0;
+}
+
 .big-avatar
 {
     max-width: 500px;

--- a/web-app/public/js/frontend.js
+++ b/web-app/public/js/frontend.js
@@ -133,6 +133,7 @@ var lib = {
                 lib.msg.auto_checker_msg.start()
                 
                 lib.ui.draw.receivers(); 
+                lib.ui.receivers.resend_to_new.init();
                 
                 lib.ajax.auto_check_refresh_auth.start();
                 
@@ -234,6 +235,14 @@ var lib = {
                     return;
                 }
                 return lib.sound.set_enabled(!!data.enabled, true);
+            });
+
+            lib.broadcast.add_listener("resend_to_new_setting_changed", function(data){
+                if (!data || !data.hasOwnProperty("enabled"))
+                {
+                    return;
+                }
+                $("#resend-to-new-toggle").prop("checked", !!data.enabled);
             });
         },
         is_version_changed: function(){
@@ -1046,7 +1055,9 @@ var lib = {
                                     else
                                     {
                                         lib.receivers.add_receiver(payload['uid'], payload['public_key']).then(function(){
-                                            resolve(msg);
+                                            return lib.msg.resend_own_messages_to_receiver_if_enabled(payload['uid']).then(function(){
+                                                resolve(msg);
+                                            });
                                         });
                                     }
                                 });
@@ -1217,6 +1228,39 @@ var lib = {
             }
         },
         receivers: {
+            resend_to_new: {
+                storage_key: "resend_to_new_enabled",
+                init: function() {
+                    var toggle = $("#resend-to-new-toggle");
+                    if (!toggle.length)
+                    {
+                        return Promise.resolve(false);
+                    }
+
+                    toggle.off("change").on("change", function(event){
+                        return lib.ui.receivers.resend_to_new.set_enabled($(event.target).prop("checked"));
+                    });
+
+                    return lib.storage.get(lib.ui.receivers.resend_to_new.storage_key, false).then(function(enabled){
+                        var checked = !!enabled;
+                        toggle.prop("checked", checked);
+                        return checked;
+                    }, helpers.reject_handler);
+                },
+                is_enabled: function() {
+                    return lib.storage.get(lib.ui.receivers.resend_to_new.storage_key, false).then(function(enabled){
+                        return !!enabled;
+                    }, helpers.reject_handler);
+                },
+                set_enabled: function(enabled) {
+                    enabled = !!enabled;
+                    $("#resend-to-new-toggle").prop("checked", enabled);
+                    return lib.storage.set(lib.ui.receivers.resend_to_new.storage_key, enabled, false).then(function(){
+                        lib.broadcast.post("resend_to_new_setting_changed", {"enabled": enabled});
+                        return enabled;
+                    }, helpers.reject_handler);
+                }
+            },
             window: {
                 current_modal: null,
                 get_content: function(uid){
@@ -3736,6 +3780,116 @@ var lib = {
                 });
             }, helpers.reject_handler);
             return Promise.all(send_promises);
+        },
+        resend_own_messages_to_receiver_if_enabled: function(receiver_uid) {
+            if (!receiver_uid || receiver_uid === lib.client.uid)
+            {
+                return Promise.resolve(false);
+            }
+
+            return lib.ui.receivers.resend_to_new.is_enabled().then(function(enabled){
+                if (!enabled)
+                {
+                    return false;
+                }
+                return lib.msg.resend_own_messages_to_receiver(receiver_uid).then(function(sent_count){
+                    if (lib.msg.debug)
+                    {
+                        console.log("Resent", sent_count, "messages to receiver", receiver_uid);
+                    }
+                    return sent_count > 0;
+                });
+            }, helpers.reject_handler);
+        },
+        resend_own_messages_to_receiver: function(receiver_uid){
+            return lib.msg.get_stored_ids().then(function(stored_ids){
+                if (!Array.isArray(stored_ids) || stored_ids.length === 0)
+                {
+                    return 0;
+                }
+
+                var load_promises = stored_ids.map(function(msg_id){
+                    return lib.storage.get("msg:" + msg_id);
+                });
+
+                return Promise.all(load_promises).then(function(stored_messages){
+                    var payload_promises = stored_messages.map(function(stored_message){
+                        if (!stored_message || stored_message.incoming || stored_message.from !== lib.client.uid)
+                        {
+                            return Promise.resolve(null);
+                        }
+
+                        if (stored_message.type === "text" && stored_message.data && stored_message.data.hasOwnProperty("text"))
+                        {
+                            return Promise.resolve({
+                                "type": "text",
+                                "text": stored_message.data.text
+                            });
+                        }
+                        if (stored_message.type === "add" && stored_message.data && stored_message.data.uid && stored_message.data.public_key)
+                        {
+                            return Promise.resolve({
+                                "type": "add",
+                                "uid": stored_message.data.uid,
+                                "public_key": stored_message.data.public_key
+                            });
+                        }
+                        if (stored_message.type === "file" && stored_message.data && stored_message.data.id)
+                        {
+                            return Promise.resolve({
+                                "type": "file",
+                                "id": stored_message.data.id,
+                                "name": stored_message.data.name,
+                                "parts": stored_message.data.parts,
+                                "size": stored_message.data.size,
+                                "transfer_size": stored_message.data.transfer_size,
+                                "sha256": stored_message.data.sha256,
+                                "mime": stored_message.data.mime,
+                                "is_image": stored_message.data.is_image,
+                                "comment": stored_message.data.comment
+                            });
+                        }
+                        if (stored_message.type === "file_part" && stored_message.data && stored_message.data.file_id && stored_message.data.part_num && stored_message.data.blob_id)
+                        {
+                            return lib.storage.get(stored_message.data.blob_id).then(function(content){
+                                if (content === null || content === undefined)
+                                {
+                                    return null;
+                                }
+                                return {
+                                    "type": "file_part",
+                                    "file_id": stored_message.data.file_id,
+                                    "part_num": stored_message.data.part_num,
+                                    "content": content
+                                };
+                            }, helpers.reject_handler);
+                        }
+
+                        return Promise.resolve(null);
+                    });
+
+                    return Promise.all(payload_promises).then(function(messages_to_resend){
+                        var send_count = 0;
+                        var send_chain = Promise.resolve();
+
+                        messages_to_resend.forEach(function(payload){
+                            if (!payload)
+                            {
+                                return;
+                            }
+                            send_chain = send_chain.then(function(){
+                                return lib.msg.send_raw(payload, [receiver_uid]).then(function(){
+                                    send_count++;
+                                });
+                            });
+                        });
+
+                        return send_chain.then(function(){
+                            return send_count;
+                        });
+                    }, helpers.reject_handler);
+                }, helpers.reject_handler);
+            }, helpers.reject_handler);
         },
         check_new: function(){
             if (lib.msg.checking_new_in_progress)

--- a/web-app/public/js/translations/en-us.js
+++ b/web-app/public/js/translations/en-us.js
@@ -36,6 +36,7 @@ window.TR['en-us'] = {
     "Send message": "Send message",
     "(enter)": "(enter)",
     "Receivers": "Receivers",
+    "Resend to new": "Resend to new",
     "Share my key": "Share my key",
     "Add new key": "Add new key",
     "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your conterpart!": "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your counterpart!",

--- a/web-app/public/js/translations/ru-ru.js
+++ b/web-app/public/js/translations/ru-ru.js
@@ -36,6 +36,7 @@ window.TR['ru-ru'] = {
     "Send message": "Отправить сообщение",
     "(enter)": "(enter)",
     "Receivers": "Получатели",
+    "Resend to new": "Переотправлять новым",
     "Share my key": "Поделиться моим ключом",
     "Add new key": "Добавить новый ключ",
     "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your conterpart!": "Чтобы снизить риск MiTM, после ввода uid и public_key обязательно сравните аватар с собеседником!",

--- a/web-app/public/js/translations/zh-cn.js
+++ b/web-app/public/js/translations/zh-cn.js
@@ -36,6 +36,7 @@ window.TR['zh-cn'] = {
     "Send message": "发送消息",
     "(enter)": "(回车)",
     "Receivers": "接收方",
+    "Resend to new": "转发给新加入者",
     "Share my key": "分享我的密钥",
     "Add new key": "添加新密钥",
     "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your conterpart!": "为降低中间人攻击风险，输入 uid 和 public_key 后请务必与对方核对头像！",

--- a/web-app/templates/clipboard.php
+++ b/web-app/templates/clipboard.php
@@ -65,6 +65,10 @@
       {Receivers}
       <div class="receivers">          
       </div>
+      <div class="form-check form-switch receivers-option">
+          <input class="form-check-input" type="checkbox" id="resend-to-new-toggle">
+          <label class="form-check-label" for="resend-to-new-toggle">{Resend to new}</label>
+      </div>
       <div class='row'>
           <div class='col'>
             <a href='/share-key' class='btn btn-success full-width'>{Share my key}</a>


### PR DESCRIPTION
### Motivation

- Provide an optional mode that automatically re-sends previously sent local messages (text, files, and key-share messages) to a receiver when their public key/UID is added. 

### Description

- Add a UI toggle to the Clipboard page (`web-app/templates/clipboard.php`) with a `#resend-to-new-toggle` checkbox and new CSS `.receivers-option` styling in `web-app/public/css/style.css`. 
- Implement client-side persistence and cross-tab sync for the setting via `lib.ui.receivers.resend_to_new` in `web-app/public/js/frontend.js`, including `init`, `is_enabled`, and `set_enabled` methods and a broadcast listener for changes. 
- Trigger resend behavior when processing incoming add-contact packets by calling `lib.msg.resend_own_messages_to_receiver_if_enabled` from the add-message parser, and implement `resend_own_messages_to_receiver_if_enabled` and `resend_own_messages_to_receiver` to load stored messages and `send_raw` them to the new receiver. 
- Add translations for the new label `Resend to new` in `web-app/public/js/translations/en-us.js`, `ru-ru.js`, and `zh-cn.js`, and document the feature in `README.md` and `SPEC.md`.

### Testing

- No automated tests were run because the repository does not include an automated test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d14a81e5288324a6fbb34c02c75bb8)