### PR TITLE
Add mobile Receivers button and responsive layout for small screens

### DIFF
--- a/web-app/public/css/style.css
+++ b/web-app/public/css/style.css
@@ -301,6 +301,11 @@ main .tab.active
     min-height: 64px;
 }
 
+.mobile-receivers-button
+{
+    display: none;
+}
+
 .key-share-link-group
 {
     max-width:520px;
@@ -486,6 +491,24 @@ main .tab.active
     .receivers-wrapper
     {
         padding-left: 3px;
+    }
+}
+
+@media screen and (max-width: 767px) {
+    .messages-wrapper
+    {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+
+    .receivers-wrapper
+    {
+        display: none;
+    }
+
+    .mobile-receivers-button
+    {
+        display: inline-block;
     }
 }
 

--- a/web-app/public/js/frontend.js
+++ b/web-app/public/js/frontend.js
@@ -1301,6 +1301,14 @@ var lib = {
                     }
                 }
             },
+            open_mobile_modal: function(){
+                var content = `
+                    <div class="mobile-receivers-modal-content">
+                        ${$(".receivers-wrapper").html()}
+                    </div>
+                `;
+                lib.modal.alert(tr("Receivers"), content);
+            },
             get_receiver_html_code: function(receiver, existing){
                 var avatar_number = -1;
                 var pencil = true;

--- a/web-app/templates/clipboard.php
+++ b/web-app/templates/clipboard.php
@@ -48,6 +48,14 @@
                       >
                       {Send message} <span class="grey">{(enter)}</span> <i class='fa fa-arrow-circle-right idle'></i>
                         </button>
+              <button type="button"
+                      class="btn btn-sm btn-light mobile-receivers-button"
+                      id="open_receivers_modal_button"
+                      title="{Receivers}"
+                      onclick='lib.ui.receivers.open_mobile_modal()'
+                      >
+                      {Receivers}
+              </button>
               <input type="file"  style="display: none;" id="file-selector" multiple onchange="lib.ui.msg.send_file_selected(event, this)">
           </div>
       </div>


### PR DESCRIPTION
### Motivation
- Allow mobile users to access the receivers list when the right-hand `receivers-wrapper` is hidden on small screens. 

### Description
- Add a `.mobile-receivers-button` element to the message controls and insert the button markup into `web-app/templates/clipboard.php` which calls `lib.ui.receivers.open_mobile_modal()` when clicked. 
- Add responsive CSS in `web-app/public/css/style.css` to hide `.receivers-wrapper` and show `.mobile-receivers-button` under `@media screen and (max-width: 767px)`, and adjust `.messages-wrapper` sizing for full-width on small screens. 
- Implement `lib.ui.receivers.open_mobile_modal` in `web-app/public/js/frontend.js` to open a modal populated with the current `.receivers-wrapper` HTML via `lib.modal.alert`. 

### Testing
- No new automated tests were added for this change. 
- The project's existing frontend build/validation and test suite were executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d4cc56f083249547cd0371aac75c)