### PR TITLE
Improve clipboard mobile UX with contacts modal

### DIFF
--- a/web-app/public/css/style.css
+++ b/web-app/public/css/style.css
@@ -509,6 +509,29 @@ main .tab.active
     margin-top:56px;
 }
 
+
+.mobile-contacts-button
+{
+    display: none;
+}
+
+@media screen and (max-width: 767px) {
+    .messages-wrapper
+    {
+        width: 100%;
+    }
+
+    .receivers-wrapper
+    {
+        display: none;
+    }
+
+    .mobile-contacts-button
+    {
+        display: inline-block;
+    }
+}
+
 .large-avatar
 {
     min-width: 200px;

--- a/web-app/public/js/frontend.js
+++ b/web-app/public/js/frontend.js
@@ -1217,6 +1217,23 @@ var lib = {
             }
         },
         receivers: {
+            mobile: {
+                current_modal: null,
+                open: function() {
+                    var content = $(".receivers-wrapper").html();
+                    lib.ui.receivers.mobile.current_modal = lib.modal.alert(tr("Contacts"), `<div class='mobile-receivers-modal'>${content}</div>`, function(){
+                        lib.ui.receivers.mobile.current_modal = null;
+                    });
+                },
+                update_if_opened: function() {
+                    var modal = lib.ui.receivers.mobile.current_modal;
+                    if (modal && $(modal).length)
+                    {
+                        var content = $(".receivers-wrapper").html();
+                        $(modal).find('.mobile-receivers-modal').html(content);
+                    }
+                }
+            },
             window: {
                 current_modal: null,
                 get_content: function(uid){
@@ -3427,12 +3444,13 @@ var lib = {
 
             }, helpers.reject_handler);
         },
-        receiver_changed: function(uid, data){
-            return Promise.all([
-                lib.ui.receivers.window.update_if_opened(uid),
-                lib.ui.draw.receivers()
-            ]);            
-        },
+            receiver_changed: function(uid, data){
+                return Promise.all([
+                    lib.ui.receivers.window.update_if_opened(uid),
+                    lib.ui.receivers.mobile.update_if_opened(),
+                    lib.ui.draw.receivers()
+                ]);
+            },
         update_receiver_obj: function(receiver_obj) {
             return lib.receivers.update_receiver(
                 receiver_obj.uid,

--- a/web-app/public/js/translations/en-us.js
+++ b/web-app/public/js/translations/en-us.js
@@ -36,6 +36,7 @@ window.TR['en-us'] = {
     "Send message": "Send message",
     "(enter)": "(enter)",
     "Receivers": "Receivers",
+    "Contacts": "Contacts",
     "Share my key": "Share my key",
     "Add new key": "Add new key",
     "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your conterpart!": "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your counterpart!",

--- a/web-app/public/js/translations/ru-ru.js
+++ b/web-app/public/js/translations/ru-ru.js
@@ -36,6 +36,7 @@ window.TR['ru-ru'] = {
     "Send message": "Отправить сообщение",
     "(enter)": "(enter)",
     "Receivers": "Получатели",
+    "Contacts": "Контакты",
     "Share my key": "Поделиться моим ключом",
     "Add new key": "Добавить новый ключ",
     "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your conterpart!": "Чтобы снизить риск MiTM, после ввода uid и public_key обязательно сравните аватар с собеседником!",

--- a/web-app/public/js/translations/zh-cn.js
+++ b/web-app/public/js/translations/zh-cn.js
@@ -36,6 +36,7 @@ window.TR['zh-cn'] = {
     "Send message": "发送消息",
     "(enter)": "(回车)",
     "Receivers": "接收方",
+    "Contacts": "联系人",
     "Share my key": "分享我的密钥",
     "Add new key": "添加新密钥",
     "To mitigate MiTM security risk, after entering uid and public_key please compare avatar with your conterpart!": "为降低中间人攻击风险，输入 uid 和 public_key 后请务必与对方核对头像！",

--- a/web-app/templates/clipboard.php
+++ b/web-app/templates/clipboard.php
@@ -47,7 +47,14 @@
                       disabled
                       >
                       {Send message} <span class="grey">{(enter)}</span> <i class='fa fa-arrow-circle-right idle'></i>
-                        </button>
+              </button>
+              <button type="button"
+                      class="btn btn-sm btn-light mobile-contacts-button"
+                      id="mobile_contacts_button"
+                      title="{Contacts}"
+                      onclick='lib.ui.receivers.mobile.open()'>
+                      {Contacts} <i class='fa fa-address-book'></i>
+              </button>
               <input type="file"  style="display: none;" id="file-selector" multiple onchange="lib.ui.msg.send_file_selected(event, this)">
           </div>
       </div>


### PR DESCRIPTION
### Motivation
- On narrow/mobile screens the right-side receivers column consumes valuable space and degrades the clipboard layout, so contacts should be hidden and exposed via a dedicated button that opens a modal.

### Description
- Added a mobile-only `Contacts` button under the send controls in `web-app/templates/clipboard.php` that invokes `lib.ui.receivers.mobile.open()`.
- Implemented `lib.ui.receivers.mobile` in `web-app/public/js/frontend.js` with `open()` and `update_if_opened()` to render the receivers list inside a modal and keep it in sync when receivers change.
- Updated `lib.receivers.receiver_changed` to refresh the mobile modal when receivers are updated.
- Added responsive CSS in `web-app/public/css/style.css` to hide `.receivers-wrapper` and expand the messages column on screens <= 767px and to show the new mobile button, and added `Contacts` translation entries in English, Russian and Chinese.

### Testing
- Verified the modified files and diffs to ensure the template, JS and CSS changes were applied successfully.
- Inspected the updated files with line-numbered prints to confirm the `mobile` receiver code and button insertion are present and consistent.
- Generated the pull request metadata and validated that the change set is contained and ready for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e38c30b483248ebccf11664cbd26)